### PR TITLE
Rewrite Sass tasks in Gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,12 +2,16 @@ var gulp = require('gulp');
 var sass = require('gulp-sass');
 var server = require('gulp-express');
 
-gulp.task('compileStyles', function() {
-	gulp.src('app/sass/*.scss')
-		.pipe(sass().on('error', sass.logError))
-		.pipe(gulp.dest('./app/css/'));
-	gulp.watch('app/sass/**/*.scss',['compileStyles']);
-});//End task compileStyles
+var input = 'app/sass/*.scss';
+var output = './app/css/';
+
+
+gulp.task('sass', function () {
+	return gulp
+	.src(input)
+	.pipe(sass(sassOptions).on('error', sass.logError))
+	.pipe(gulp.dest(output));
+});
 
 gulp.task('copy', function() {
 	gulp.src([
@@ -32,4 +36,4 @@ gulp.task('server', function () {
 	server.run(['server.js']);
 });//End task server
 
-gulp.task('default', ['compileStyles','copy','server']);
+gulp.task('default', ['copy','server']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ gulp.task('sass', function () {
 	.src(input)
 	.pipe(sourcemaps.init())
 	.pipe(sass(sassOptions).on('error', sass.logError))
-	.pipe(sourcemaps.write())
+	.pipe(sourcemaps.write('./app/css/maps'))
 	.pipe(gulp.dest(output));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,9 +4,9 @@ var sourcemaps = require('gulp-sourcemaps');
 var autoprefixer = require('gulp-autoprefixer');
 var server = require('gulp-express');
 
+//Sass variables
 var input = './app/sass/*.scss';
 var output = './app/css/';
-
 var sassOptions = {
 	errLogToConsole: true,
 	outputStyle: 'expanded'
@@ -17,10 +17,10 @@ gulp.task('sass', function () {
 	.src(input)
 	.pipe(sourcemaps.init())
 	.pipe(sass(sassOptions).on('error', sass.logError))
-	.pipe(sourcemaps.write('./app/css/maps'))
+	.pipe(sourcemaps.write())
 	.pipe(autoprefixer())
-	.pipe(gulp.dest(output));
-});
+	.pipe(gulp.dest(output))
+});//End task sass
 
 gulp.task('watch', function() {
 	return gulp
@@ -28,7 +28,7 @@ gulp.task('watch', function() {
 	.on('change', function(event) {
 	console.log('File ' + event.path + ' was ' + event.type + ', running tasks...');
 	});
-});
+});//End tastk watch
 
 gulp.task('copy', function() {
 	gulp.src([

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
+var autoprefixer = require('gulp-autoprefixer');
 var server = require('gulp-express');
 
 var input = './app/sass/*.scss';
@@ -13,6 +14,7 @@ gulp.task('sass', function () {
 	.pipe(sourcemaps.init())
 	.pipe(sass(sassOptions).on('error', sass.logError))
 	.pipe(sourcemaps.write('./app/css/maps'))
+	.pipe(autoprefixer())
 	.pipe(gulp.dest(output));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@ var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
 var server = require('gulp-express');
 
-var input = 'app/sass/*.scss';
+var input = './app/sass/*.scss';
 var output = './app/css/';
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ var server = require('gulp-express');
 var input = './app/sass/*.scss';
 var output = './app/css/';
 
-
 gulp.task('sass', function () {
 	return gulp
 	.src(input)
@@ -16,6 +15,14 @@ gulp.task('sass', function () {
 	.pipe(sourcemaps.write('./app/css/maps'))
 	.pipe(autoprefixer())
 	.pipe(gulp.dest(output));
+});
+
+gulp.task('watch', function() {
+	return gulp
+	.watch(input, ['sass'])
+	.on('change', function(event) {
+	console.log('File ' + event.path + ' was ' + event.type + ', running tasks...');
+	});
 });
 
 gulp.task('copy', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,11 @@ var server = require('gulp-express');
 var input = './app/sass/*.scss';
 var output = './app/css/';
 
+var sassOptions = {
+	errLogToConsole: true,
+	outputStyle: 'expanded'
+};
+
 gulp.task('sass', function () {
 	return gulp
 	.src(input)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,4 +48,4 @@ gulp.task('server', function () {
 	server.run(['server.js']);
 });//End task server
 
-gulp.task('default', ['copy','server']);
+gulp.task('default', ['sass','watch','copy','server']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp');
 var sass = require('gulp-sass');
+var sourcemaps = require('gulp-sourcemaps');
 var server = require('gulp-express');
 
 var input = 'app/sass/*.scss';
@@ -9,7 +10,9 @@ var output = './app/css/';
 gulp.task('sass', function () {
 	return gulp
 	.src(input)
+	.pipe(sourcemaps.init())
 	.pipe(sass(sassOptions).on('error', sass.logError))
+	.pipe(sourcemaps.write())
 	.pipe(gulp.dest(output));
 });
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "font-awesome": "^4.5.0",
     "gulp": "^3.9.0",
+    "gulp-autoprefixer": "^3.1.0",
     "gulp-sass": "^2.2.0",
     "gulp-sourcemaps": "^1.6.0",
     "sweet-feedback": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "font-awesome": "^4.5.0",
     "gulp": "^3.9.0",
     "gulp-sass": "^2.2.0",
+    "gulp-sourcemaps": "^1.6.0",
     "sweet-feedback": "^1.0.1"
   }
 }


### PR DESCRIPTION
The old task was resulting in a HUDGE loop that crash all gulp tasks. I rewrite it in a better way, add gulp-sourcemaps (to make easy to debug CSS compiled files) and gulp-autoprefix (So we don’t need to worry about write prefixes like -webkit or -moz to make our CSS code compatible in the most popular browsers.)
