### PR TITLE
 Remove Preferences from application header

### DIFF
--- a/app/angular/controller/optionsController.js
+++ b/app/angular/controller/optionsController.js
@@ -3,9 +3,6 @@ var app = angular.module('myapp');
 app.controller('optionsController', function($scope, $state, AuthService) {
 
 	$scope.menuItens = [{
-			text: "Preferências",
-			action: function(){}
-		}, {
 			text: "Sair",
 			action: function(){
 				AuthService.logout();


### PR DESCRIPTION
# Summary 

In the main header of **BRModelo** we present a cog icon that allow users to access two options:
1. Preferences
2. Logout

At the moment **Preferences** is just a placeholder since we still don't have a page or content to show. Due to this, if clicked that option is redirecting users to login page. To avoid this misguiding behavior we're removing **Preferences** from the menu. 

# Screenshots

<table>
<thead>
<th>Before</th>
<th>After</th>
</thead>
<tbody>
<tr>
<td>

![Screen Shot 2020-08-03 at 21 09 46](https://user-images.githubusercontent.com/301545/89218378-378a2100-d5ce-11ea-9fae-0ccf96bd161a.png)

</td>
<td>

![Screen Shot 2020-08-03 at 21 09 34](https://user-images.githubusercontent.com/301545/89218371-335e0380-d5ce-11ea-9e3a-1972da79bf2e.png)

</td>
</tr>
</tbody>
</table>

