### PR TITLE
Fixes button alignment on signup form

### DIFF
--- a/app/angular/recovery/recovery.html
+++ b/app/angular/recovery/recovery.html
@@ -31,7 +31,7 @@
 				<button type="submit" class="br-button btn-block">Recuperar</button>
 			</form>
 			<aside class="account-options">
-				<a href="#" tabindex="1" data-ui-sref="login">voltar</a>
+				<a href="#" tabindex="1" data-ui-sref="login">Voltar</a>
 			<aside>
 		</section>
 	</div>

--- a/app/angular/signup/signup.html
+++ b/app/angular/signup/signup.html
@@ -58,8 +58,8 @@
 				</div>
 				<button type="submit" class="br-button btn-block">Criar conta</button>
 			</form>
-			<aside class="new-account">
-				<a href="#" tabindex="1" data-ui-sref="login">voltar</a>
+			<aside class="account-options">
+				<a href="#" tabindex="1" data-ui-sref="login">Voltar</a>
 			<aside>
 		</section>
 	</div>


### PR DESCRIPTION
### Description

After we added the recovery password option, some HTML structure had changed and the a back button at signup screen ended aligned to the left, when it should actually be centered. 

This PR will fix the miss alignment of both buttons.

### Screenshots

| Before | After |
| ------ | ------ | 
| ![image](https://user-images.githubusercontent.com/25749372/124397550-d3dd0c00-dce6-11eb-88b7-b662bbe387da.png) | ![image](https://user-images.githubusercontent.com/25749372/124397559-e3f4eb80-dce6-11eb-91e5-de9f9751b634.png) |