### PR TITLE
Show the right sidebar expanded by default

### DIFF
--- a/app/angular/controller/models/conceptualController.js
+++ b/app/angular/controller/models/conceptualController.js
@@ -31,7 +31,7 @@ angular.module('myapp')
 		user: $rootScope.loggeduser
 	}
 
-	$scope.editionVisible = false;
+	$scope.editionVisible = true;
 	$scope.dropdownVisible = false;
 	$scope.shouldShow = false;
 	$scope.isElementSelected = false;

--- a/app/angular/controller/models/logicController.js
+++ b/app/angular/controller/models/logicController.js
@@ -17,7 +17,7 @@ angular.module('myapp')
 	$scope.selectedName = "";
 	$scope.selectedElement = null;
 	$scope.columns = [];
-	$scope.editionVisible = false;
+	$scope.editionVisible = true;
 	$scope.tableNames = [];
 	self.mapTables = {};
 

--- a/app/angular/view/conceptual.html
+++ b/app/angular/view/conceptual.html
@@ -61,6 +61,10 @@
 				<i class="fa angle-double-icon" data-ng-class="!editionVisible ? 'fa-angle-double-left' : 'fa-angle-double-right'"></i>
 			</span>
 
+			<div class="model-properties__empty-state" ng-show="entitySelected === 'NONE'">
+				<span>Nenhum elemento selecionado.</span>
+			</div>
+
 			<div class="properties-content">
 
 				<div

--- a/app/angular/view/logic.html
+++ b/app/angular/view/logic.html
@@ -59,6 +59,10 @@
 					<i class="fa angle-double-icon" data-ng-class="!editionVisible ? 'fa-angle-double-left' : 'fa-angle-double-right'"></i>
 				</span>
 
+				<div class="model-properties__empty-state" ng-show="!selectedElement">
+					<span>Nenhum elemento selecionado.</span>
+				</div>
+
 				<div class="properties-content" ng-show="selectedElement != null">
 
 					<div class="form-group">

--- a/app/sass/structure.scss
+++ b/app/sass/structure.scss
@@ -138,6 +138,10 @@ a,
 	cursor: pointer;
 }
 
+.model-properties__empty-state {
+	padding: 16px;
+}
+
 .action .angle-double-icon {
 	position: relative;
 	top: 3px;


### PR DESCRIPTION
### Description

Today, users are completely missing the sidebar, this is a big problem because part of crucial BR Modelo Web functionalities lives in the sidebar.

We'll show the right sidebar expanded by default, as a quick solution and add an empty state block to be visible when the user has no element selected.

### Screnshoots
![image](https://user-images.githubusercontent.com/25749372/127939271-68b6cfed-32b7-40b7-94b4-fce528d65385.png)
