### PR TITLE
Fix JointJS style in the logic model

### DIFF
--- a/app/angular/conceptual/conceptual.js
+++ b/app/angular/conceptual/conceptual.js
@@ -2,7 +2,6 @@ import "backbone";
 import $ from "jquery";
 
 import * as joint from "jointjs/dist/joint";
-import jointCss from "jointjs/dist/joint.min.css";
 
 import "../../joint/joint.ui.stencil";
 import "../../joint/joint.ui.stencil.css";
@@ -14,12 +13,6 @@ import "../../joint/br-scroller";
 import "../../joint/joint.dia.command";
 import shapes from "../../joint/shapes";
 joint.shapes.erd = shapes;
-
-/*
- * This line prevent a sideEffect issue in jointjs library that make webpack ignore joint css imports
- * See more: https://github.com/webpack/webpack/issues/8814
- */
-console.log(jointCss)
 
 import angular from "angular";
 import template from "./conceptual.html";

--- a/app/angular/index.js
+++ b/app/angular/index.js
@@ -7,6 +7,7 @@ import "angular-translate";
 import "textangular";
 
 import "jointjs";
+import jointCss from "jointjs/dist/joint.min.css";
 import "bootstrap/dist/css/bootstrap.css";
 import "font-awesome/css/font-awesome.min.css";
 import "../sass/app.scss";
@@ -27,6 +28,12 @@ import logicFactory from "./service/logicFactory";
 
 import pt_BR from "../i18n/languages/pt_BR";
 import en from "../i18n/languages/en";
+
+/*
+ * This line prevent a sideEffect issue in jointjs library that make webpack ignore joint css imports
+ * See more: https://github.com/webpack/webpack/issues/8814
+ */
+console.log(jointCss)
 
 const app = angular.module("app", [
 	"ui.router",


### PR DESCRIPTION
This PR adds a workaround that fixes an issue related to a JointJS library sideEffect config. The https://github.com/brmodeloweb/brmodelo-app/pull/245 fixed only for the conceptual modal, and this PR fixes the problem for the logic model as well, by moving the solution code to the common ancestral.
