### PR TITLE
Fix list display after duplicate model action

### DIFF
--- a/app/angular/workspace/workspace.js
+++ b/app/angular/workspace/workspace.js
@@ -132,6 +132,8 @@ const ListController = function (
 				user: model.who,
 			};
 			ModelAPI.saveModel(duplicatedModel).then((newModel) => {
+				newModel.authorName = model.authorName;
+				newModel.typeName = model.typeName;
 				ctrl.models.push(newModel);
 				showLoading(false);
 			});


### PR DESCRIPTION
This pull request fixes #268 

**Steps to reproduce**
1. Login with a valid-user
2. Duplicate a model

**Expected behavior**
All fields from the duplicated field should have data (type, name, author, and date of creation)

@wlsf82 thanks for reporting mate ;) 



