### PR TITLE
Add test for switching languages

### DIFF
--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -19,6 +19,23 @@ describe("Login", () => {
 		cy.contains("h2", "Models").should("be.visible");
 	});
 
+	it("switches languages", () => {
+		cy.visit("/");
+
+		cy.get('button[type="submit"]')
+			.as("submitButton")
+			.should("contain", "Login")
+			.and("be.visible");
+
+		cy.get(".country-flag[alt='Brazil flag']").click();
+
+		cy.get("@submitButton").should("contain", "Entrar").and("be.visible");
+
+		cy.get(".country-flag[alt='United States flag']").click();
+
+		cy.get("@submitButton").should("contain", "Login").and("be.visible");
+	});
+
 	context("Form validations", () => {
 		it("alerts on invalid user email", () => {
 			cy.login("invalid#user.com", password, useCachedSession);


### PR DESCRIPTION
A test for that had been added before, by @ArthurMota9, during internationalization, but when dealing with conflicts [in another PR](https://github.com/brmodeloweb/brmodelo-app/pull/267), I deleted this test by mistake, and so, I'm putting it back.