### PR TITLE
Increase models view test coverage

### DIFF
--- a/cypress/integration/models.spec.js
+++ b/cypress/integration/models.spec.js
@@ -43,4 +43,35 @@ describe("Models view", () => {
 		cy.wait("@deleteModels").its("response.statusCode").should("be.equal", 200);
 		cy.get("table tbody tr.listLine").should("not.exist");
 	});
+
+	it("opens and closes the modals", () => {
+		// Opens the rename model modal
+		cy.get(".fa-pencil").click({ force: true });
+		// Make sure the modal is visible and closes it
+		cy.get(".modal-dialog")
+			.as("modal")
+			.should("be.visible")
+			.find("button:contains(Cancel)")
+			.click();
+		// Make sure the modal doesn't exist in the DOM anymore
+		cy.get("@modal").should("not.exist");
+		// Opens the duplicate model modal
+		cy.get(".fa-files-o").click({ force: true });
+		// Make sure the modal is visible and closes it
+		cy.get("@modal")
+			.should("be.visible")
+			.find("button:contains(Cancel)")
+			.click();
+		// Make sure the modal doesn't exist in the DOM anymore
+		cy.get("@modal").should("not.exist");
+		// Opens the delete model modal
+		cy.get(".fa-trash").click({ force: true });
+		// Make sure the modal is visible and closes it
+		cy.get("@modal")
+			.should("be.visible")
+			.find("button:contains(Cancel)")
+			.click();
+		// Make sure the modal doesn't exist in the DOM anymore
+		cy.get("@modal").should("not.exist");
+	});
 });


### PR DESCRIPTION
Now, besides testing that we can rename, duplicate and delete a model, we also have a test that makes sure that clicking the cancel button closes the modal for these three options (renaming, duplicating, and deleting.)

https://user-images.githubusercontent.com/2768415/144499936-a5362403-b698-4b61-92a2-a557deb30286.mp4