### PR TITLE
Add test for a conceptual model creation via API call

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,5 @@
   "apiUrl": "http://localhost:3000",
   "experimentalSessionSupport": true,
   "baseUrl": "http://localhost:9000",
-  "fixturesFolder": false,
   "pluginsFile": false
 }

--- a/cypress/fixtures/conceptualModel.json
+++ b/cypress/fixtures/conceptualModel.json
@@ -1,0 +1,57 @@
+{
+  "cells": [
+    {
+      "type": "erd.Entity",
+      "supertype": "Entity",
+      "isExtended": false,
+      "autorelationship": false,
+      "size": { "width": 80, "height": 40 },
+      "position": { "x": 170, "y": 50 },
+      "angle": 0,
+      "id": "bdb20ca0-5c43-40b2-94dd-d0aecfa5b856",
+      "z": 1,
+      "attrs": {}
+    },
+    {
+      "type": "erd.Relationship",
+      "supertype": "Relationship",
+      "autorelationship": false,
+      "size": { "width": 85, "height": 45 },
+      "position": { "x": 330, "y": 50 },
+      "angle": 0,
+      "id": "36ec2d5d-4084-4c42-add9-aa3afddedae3",
+      "z": 2,
+      "attrs": {}
+    },
+    {
+      "type": "erd.Link",
+      "source": { "id": "36ec2d5d-4084-4c42-add9-aa3afddedae3" },
+      "target": { "id": "bdb20ca0-5c43-40b2-94dd-d0aecfa5b856" },
+      "id": "7ad0455f-5a16-46f4-bc69-dc1090a55978",
+      "z": 3,
+      "labels": [{ "position": 0.7, "attrs": { "text": { "text": "(0, n)" } } }],
+      "attrs": {}
+    },
+    {
+      "type": "erd.Entity",
+      "supertype": "Entity",
+      "isExtended": false,
+      "autorelationship": false,
+      "size": { "width": 80, "height": 40 },
+      "position": { "x": 510, "y": 60 },
+      "angle": 0,
+      "id": "1846af3e-6e30-4471-ba8b-6829cab94050",
+      "z": 4,
+      "attrs": {}
+    },
+    {
+      "type": "erd.Link",
+      "source": { "id": "36ec2d5d-4084-4c42-add9-aa3afddedae3" },
+      "target": { "id": "1846af3e-6e30-4471-ba8b-6829cab94050" },
+      "id": "69c1eca8-34f7-4ec0-8855-93f12f1ebc4f",
+      "z": 5,
+      "labels": [{ "position": 0.7, "attrs": { "text": { "text": "(0, n)" } } }],
+      "attrs": {}
+    }
+  ]
+}

--- a/cypress/integration/api/model.spec.js
+++ b/cypress/integration/api/model.spec.js
@@ -1,0 +1,30 @@
+const conceptualModel = require("../../fixtures/conceptualModel.json");
+
+describe("Models - Creation via API call", () => {
+	beforeEach(() => {
+		cy.intercept("GET", "/models?userId=*").as("getUserModels");
+		cy.login();
+		cy.visit("/#!/main");
+		cy.wait("@getUserModels").then((userModels) => {
+			cy.cleanUpUserModels(userModels);
+		});
+		cy.reload();
+	});
+
+	it("successfully creates a conceptual model via API", () => {
+		cy.wait("@getUserModels").then((userModels) => {
+			const userId = userModels.request.url.match(/userId=([^&]*)/)[1];
+
+			cy.createModelViaApi("conceptual", userId, conceptualModel);
+		});
+		cy.reload();
+		cy.contains("td", "Conceptual").click();
+
+		cy.get(".paper-scroller [data-type='erd.Entity']").should("have.length", 2);
+		cy.get(".paper-scroller [data-type='erd.Relationship']").should(
+			"have.length",
+			1
+		);
+		cy.get(".paper-scroller [data-type='erd.Link']").should("have.length", 2);
+	});
+});

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -49,10 +49,12 @@ declare namespace Cypress {
      * 
      * @param type string - The type of the model you want to create. The allowed types are 'conceptual' and 'logical'
      * @param userId string - The id of the user for which you want to create the model
+     * @param model object - An object with a cells property as an array, defining all "cells" of a model. Default is an object with an empty array as the value of the cells property
      * 
      * @example cy.createModelViaApi('conceptual', '618f065ed18dc91b10650f99') // Creates a conceptual model for userId=618f065ed18dc91b10650f99
      * @example cy.createModelViaApi('logical', '618f065ed18dc91b10650f99') // Creates a logical model for userId=618f065ed18dc91b10650f99
+     * @example cy.createModelViaApi('conceptual', '618f065ed18dc91b10650f99', conceptualModel) // Creates a conceptual model for userId=618f065ed18dc91b10650f99 passing a model object (`conceptualModel`), defined earlier, as a variable
      */
-    createModelViaApi(type, userId): Cypress.Chainable<Cypress.Response<any>>
+    createModelViaApi(type: string, userId: string, model?: object): Cypress.Chainable<Cypress.Response<any>>
   }
 }

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -24,7 +24,7 @@ declare namespace Cypress {
      * 
      * @example cy.cleanUpUserModels(userModelsResponseObject) // Cleans up all models for the logged in user
      */
-    cleanUpUserModels(userModelsRespondeObject): Cypress.Chainable<Cypress.Response<any>>
+    cleanUpUserModels(userModelsRespondeObject: object): Cypress.Chainable<Cypress.Response<any>>
 
     /**
      * **Gets all user models for a specific userId via a GET request.**
@@ -33,7 +33,7 @@ declare namespace Cypress {
      * 
      * @example cy.getUserModelsViaApi('http://localhost:3000/models?userId=618f065ed18dc91b10651g98') // Gets all user models for userId=618f065ed18dc91b10651g98
      */
-    getUserModelsViaApi(url): Cypress.Chainable<Cypress.Response<any>>
+    getUserModelsViaApi(url: string): Cypress.Chainable<Cypress.Response<any>>
 
     /**
      * **Deletes a model via a DELETE request.**
@@ -42,7 +42,7 @@ declare namespace Cypress {
      * 
      * @example cy.deleteModelViaApi('61a8db9bc67e9824b66fc8g2')
      */
-    deleteModelViaApi(modelId): Cypress.Chainable<Cypress.Response<any>>
+    deleteModelViaApi(modelId: string): Cypress.Chainable<Cypress.Response<any>>
 
     /**
      * **Creates a model via POST request.**

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -44,15 +44,18 @@ Cypress.Commands.add("deleteModelViaApi", (modelId) => {
 	);
 });
 
-Cypress.Commands.add("createModelViaApi", (type, userId) => {
-	cy.request({
-		method: "POST",
-		url: `${Cypress.config("apiUrl")}/models`,
-		body: {
-			name: animal.type(),
-			user: userId,
-			type,
-			model: { cells: [] },
-		},
-	});
-});
+Cypress.Commands.add(
+	"createModelViaApi",
+	(type, userId, model = { cell: [] }) => {
+		cy.request({
+			method: "POST",
+			url: `${Cypress.config("apiUrl")}/models`,
+			body: {
+				name: animal.type(),
+				user: userId,
+				type,
+				model,
+			},
+		});
+	}
+);


### PR DESCRIPTION
This test approach will allow us to test complex models without having to go through the graphical user interface (GUI) for their creation, consequently avoiding the usage of drag and drop to create such complex models.

This approach will also speed up the tests since API calls happen much faster than interaction via GUI.

For more details, read each commit message (titles and descriptions).

See a video of the new test below.

https://user-images.githubusercontent.com/2768415/144533531-06b57f3b-bd98-4a3d-8080-070a76c68bc3.mp4