### PR TITLE
Make test more robust

### DIFF
--- a/cypress/integration/models.spec.js
+++ b/cypress/integration/models.spec.js
@@ -27,8 +27,10 @@ describe("Models view", () => {
 	});
 
 	it("duplicates a model", () => {
+		cy.intercept("POST", "/models").as("postModel");
 		cy.get(".fa-files-o").click({ force: true });
 		cy.contains("button", "Save").click();
+		cy.wait("@postModel").its("response.statusCode").should("be.equal", 200);
 		cy.reload();
 		cy.get("tr.listLine")
 			.should("have.length", 2)


### PR DESCRIPTION
When running this test against a remote MongoDB, things happen slower than running it against a local DB.

Without this change, the `cy.reload()` command can happen too fast, making the POST request to `/models` to be canceled.

With this change, we make sure `cy.reload()` only happens after Cypress has waited for the request to happen.