### PR TITLE
Add EditoConfig to list of applications you will need to run the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 To run this application you'll need:
 
+- [EditorConfig](https://editorconfig.org/)
 - [Node.js](https://nodejs.org/) (Strongly recommended to install it via [nvm](https://github.com/nvm-sh/nvm#readme) or [n](https://github.com/tj/n#readme))
 - [Yarn](https://yarnpkg.com/)
 - [MongoDB Community Edition](https://www.mongodb.com/) (Check [installation guides](https://docs.mongodb.com/manual/installation/))


### PR DESCRIPTION
# Summary

In order to keep code style consistency and respect the rules imposed by `.editorconfig`, I'm adding [EditorConfig](https://editorconfig.org/) to the list of apps you need to run the project locally.

Ideally this is not gonna be needed soon once we introduce code linter. :)