### PR TITLE
Move custom command and document it

### DIFF
--- a/cypress/integration/model.spec.js
+++ b/cypress/integration/model.spec.js
@@ -63,7 +63,3 @@ describe("Model", () => {
 		});
 	});
 });
-
-Cypress.Commands.add("dragAndDropTableAt", (x, y) => {
-	cy.get(".joint-type-uml-class").move({ deltaX: x, deltaY: y });
-});

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -56,5 +56,15 @@ declare namespace Cypress {
      * @example cy.createModelViaApi('conceptual', '618f065ed18dc91b10650f99', conceptualModel) // Creates a conceptual model for userId=618f065ed18dc91b10650f99 passing a model object (`conceptualModel`), defined earlier, as a variable
      */
     createModelViaApi(type: string, userId: string, model?: object): Cypress.Chainable<Cypress.Response<any>>
+
+    /**
+     * **Moves the table element from the sidebar of the logical model creation view X pixels to its right, and Y pixels down.**
+     *
+     * @param deltaX number - The distance (to the right) in pixels relative to the element's current position
+     * @param deltaY number - The distance (down) in pixels relative to the element's current position
+     *
+     * @example cy.dragAndDropTableAt(200, 200) // Moves the table element from the sidebar of the logical model creation view 200 pixels to its right, and 200 pixels down
+     */
+    dragAndDropTableAt(deltaX: number, deltaY: number): Chainable<Element>
   }
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -59,3 +59,7 @@ Cypress.Commands.add(
 		});
 	}
 );
+
+Cypress.Commands.add("dragAndDropTableAt", (x, y) => {
+	cy.get(".joint-type-uml-class").move({ deltaX: x, deltaY: y });
+});


### PR DESCRIPTION
Since all other custom commands are defined at `cypress/support/commands.js`, let's have the one that drags and drops the table element to the canvas there too.

Also, added missing docs for such a command.