### PR TITLE
Add column only if has target table (fix cypress test and console error)

### DIFF
--- a/app/angular/service/logicService.js
+++ b/app/angular/service/logicService.js
@@ -311,7 +311,7 @@ const logicService = ($rootScope, ModelAPI, LogicFactory, LogicConversorService)
 			idLink: link.id,
 		});
 
-		target.addAttribute(column);
+		if (target) target.addAttribute(column);
 		$rootScope.$broadcast('element:update', ls.paper.findViewByModel(target));
 	}
 


### PR DESCRIPTION
### Description

In the logical model, when trying to link a table without selecting a target table, an error occurs in the console.

![image](https://user-images.githubusercontent.com/25749372/145502178-c86dcb5b-012c-4c2f-8817-85126d872499.png)
