### PR TITLE
Remove unnecessary visit commands from tests

### DIFF
--- a/cypress/integration/api/model.spec.js
+++ b/cypress/integration/api/model.spec.js
@@ -4,7 +4,6 @@ describe("Models - Creation via API call", () => {
 	beforeEach(() => {
 		cy.intercept("GET", "/models?userId=*").as("getUserModels");
 		cy.loginViaApi();
-		cy.visit("/#!/main");
 		cy.wait("@getUserModels").then((userModels) => {
 			cy.cleanUpUserModels(userModels);
 		});

--- a/cypress/integration/model.spec.js
+++ b/cypress/integration/model.spec.js
@@ -4,7 +4,6 @@ describe("Model", () => {
 	beforeEach(() => {
 		cy.intercept("GET", "/models?userId=*").as("getUserModels");
 		cy.loginViaApi();
-		cy.visit("/#!/main");
 		cy.wait("@getUserModels").then((userModels) => {
 			cy.cleanUpUserModels(userModels);
 			cy.reload();

--- a/cypress/integration/models.spec.js
+++ b/cypress/integration/models.spec.js
@@ -6,7 +6,6 @@ describe("Models view", () => {
 	beforeEach(() => {
 		cy.intercept("GET", "/models?userId=*").as("getUserModels");
 		cy.loginViaApi();
-		cy.visit("/#!/main");
 		cy.wait("@getUserModels").then((userModels) => {
 			const userId = userModels.request.url.match(/userId=([^&]*)/)[1];
 


### PR DESCRIPTION
The `loginViaApi` custom command already visits the home page after setting the cookies.