### PR TITLE
Add link to documentation page

### DIFF
--- a/app/angular/components/dropdownIcon.html
+++ b/app/angular/components/dropdownIcon.html
@@ -7,6 +7,16 @@
 			<a
 				target="_blank"
 				rel="noopener noreferrer"
+				href="https://docs.brmodeloweb.com"
+			>
+				{{'Documentation' | translate}}
+			</a>
+		</li>
+		<li role="separator" class="divider"></li>
+		<li>
+			<a
+				target="_blank"
+				rel="noopener noreferrer"
 				href="https://github.com/brmodeloweb/brmodelo-app/issues/new?assignees=&labels=Feature+request&template=feature_request.md&title="
 			>
 				{{'Request feature' | translate}}


### PR DESCRIPTION
# Summary

Add link to our [new documentation page](https://docs.brmodeloweb.com) to user menu.

# Screenshot

![Screen Shot 2021-12-22 at 01 05 52](https://user-images.githubusercontent.com/301545/147013253-c6f59b3e-5021-44f8-b8a9-c1d93d21d36d.png)

