### PR TITLE
Remove devDependency added by mistake

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "underscore": "^1.12.0"
   },
   "devDependencies": {
-    "9": "^0.0.1",
     "@4tw/cypress-drag-drop": "^2.1.0",
     "@babel/core": "^7.12.10",
     "@babel/node": "^7.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"9@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/9/-/9-0.0.1.tgz#25717007959445f9351ed53e87f53c22885eb1ae"
-  integrity sha1-JXFwB5WURfk1HtU+h/U8Iohesa4=
-
 "@4tw/cypress-drag-drop@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.1.0.tgz#d8f34fef9e324e964a90e92b54e393f447931959"


### PR DESCRIPTION
# Summary

Remove devDependency added by mistake  
After ask to the team why we have `9` as devDependency, a classic case of the `git blame` meme: https://github.com/brmodeloweb/brmodelo-app/commit/58e85b63d790825231095f1dc75e33bc1bb070d6

![git-blame](https://user-images.githubusercontent.com/301545/147149448-afb5dbd3-c561-4d7c-8925-8b13a6452e8f.jpeg)

