### PR TITLE
Prevent link from being detached

### DIFF
--- a/app/angular/conceptual/conceptual.js
+++ b/app/angular/conceptual/conceptual.js
@@ -460,7 +460,8 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 			drawGrid: true,
 			model: configs.graph,
 			linkConnectionPoint: joint.util.shapePerimeterConnectionPoint,
-			cellViewNamespace: joint.shapes
+			cellViewNamespace: joint.shapes,
+			linkPinning: false
 		});
 
 		configs.keyboardController = new KeyboardController(configs.paper.$document);

--- a/app/angular/service/logicService.js
+++ b/app/angular/service/logicService.js
@@ -44,7 +44,8 @@ const logicService = ($rootScope, ModelAPI, LogicFactory, LogicConversorService)
 			height: $('#content').height(),
 			gridSize: 10,
 			drawGrid: true,
-			model: ls.graph
+			model: ls.graph,
+			linkPinning: false
 		});
 
 		ls.editorActions = new joint.ui.EditorActions({ graph: ls.graph });


### PR DESCRIPTION
This pull request change a property of paper which prevents a link from being detached from its original element, the effect is that the link will be returned to its original position whenever the user drops it somewhere in a blank paper area.

Fix issues #345 and #340 