### PR TITLE
Emails deveriam ignorar letras maiusculas.

### DIFF
--- a/server_app/user/service.js
+++ b/server_app/user/service.js
@@ -6,6 +6,7 @@ const modelService = require("../model/service");
 const login = async ({ username, password }) => {
   return new Promise(async (resolve, reject) => {
     try {
+      username = username.toLowerCase();
       const userDocument = await UserRepository.findOne({
         "login": username,
         "password": encriptor.Crypto(password, username),
@@ -29,6 +30,7 @@ const login = async ({ username, password }) => {
 const create = async ({ username, password, mail }) => {
   return new Promise(async (resolve, reject) => {
     try {
+      mail = mail.toLowerCase();
       const user = await UserRepository.findOne({ "login": mail });
 
       if (user != null) {
@@ -52,6 +54,7 @@ const create = async ({ username, password, mail }) => {
 const recovery = async (email) => {
   return new Promise(async (resolve, reject) => {
     try {
+      email = email.toLowerCase();
       const user = await UserRepository.findOne({ "login": email });
 
       if (user == null) {
@@ -89,6 +92,7 @@ const recovery = async (email) => {
 
 const isValidRecovery = async (mail, code) => {
   try {
+    mail = mail.toLowerCase();
     const user = await UserRepository.findOne({ "login": mail, "recoveryCode": code });
 
     if (user == null) {
@@ -105,7 +109,7 @@ const isValidRecovery = async (mail, code) => {
 const resetPassword = async (mail, code, newPassword) => {
   return new Promise(async (resolve, reject) => {
     try {
-
+      mail = mail.toLowerCase();
       const isValid = await isValidRecovery(mail, code)
       if (!isValid) {
         return reject(new Error("Invalid recovery code"));


### PR DESCRIPTION
Estava fazendo o cadastro no sistema pelo meu tablet, e algumas letras no email estavam em maisculas, porém ignorei e segui em frente. Fui acessar pelo computador e não encontrou meu usuário, e não lembro quais eram maisculas, porém um email deve ser único ignorando letras captalizadas.

Fiz uma correção na service do user que sempre transforma o 'login' ou o 'email' em minuscula ao enviar para o banco de dados. Acredito que essa correção é essencial para evitar que multiplos emails iguais porém com caracteres maiusculas alternados sejam cadastrados. 