### PR TITLE
Feature/shortcuts

### DIFF
--- a/app/angular/components/keyboardController.js
+++ b/app/angular/components/keyboardController.js
@@ -8,6 +8,9 @@ export const types = {
 	ZOOM_OUT: 'zoomOut',
 	ZOOM_NONE: 'zoomNone',
 	ESC: 'esc',
+	DELETE: 'delete',
+	COPY: 'copy',
+	PASTE: 'paste',
 }
 
 export default class KeyboardController {
@@ -54,6 +57,9 @@ export default class KeyboardController {
 			{ key: 'command+s, ctrl+s', eventName: types.SAVE },
 			{ key: 'command+z, ctrl+z', eventName: types.UNDO },
 			{ key: 'command+shift+z, ctrl+shift+z', eventName: types.REDO },
+			{ key: 'command+d, ctrl+d', eventName: types.DELETE },
+			{ key: 'command+c, ctrl+c', eventName: types.COPY },
+			{ key: 'command+v, ctrl+v', eventName: types.PASTE },
 			{ key: 'z+=', eventName: types.ZOOM_IN },
 			{ key: 'z+-', eventName: types.ZOOM_OUT },
 			{ key: 'z+0', eventName: types.ZOOM_NONE },

--- a/app/angular/components/keyboardController.js
+++ b/app/angular/components/keyboardController.js
@@ -57,7 +57,7 @@ export default class KeyboardController {
 			{ key: 'command+s, ctrl+s', eventName: types.SAVE },
 			{ key: 'command+z, ctrl+z', eventName: types.UNDO },
 			{ key: 'command+shift+z, ctrl+shift+z', eventName: types.REDO },
-			{ key: 'command+d, ctrl+d', eventName: types.DELETE },
+			{ key: 'command+backspace, ctrl+backspace', eventName: types.DELETE },
 			{ key: 'command+c, ctrl+c', eventName: types.COPY },
 			{ key: 'command+v, ctrl+v', eventName: types.PASTE },
 			{ key: 'z+=', eventName: types.ZOOM_IN },

--- a/app/angular/conceptual/conceptual.js
+++ b/app/angular/conceptual/conceptual.js
@@ -7,7 +7,7 @@ import "../editor/editorManager";
 import "../editor/editorScroller";
 import "../editor/editorActions";
 import "../editor/elementActions";
-import "../editor/elementSelector";
+//import "../editor/elementSelector";
 
 import shapes from "../../joint/shapes";
 joint.shapes.erd = shapes;
@@ -46,7 +46,7 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 		user: $rootScope.loggeduser
 	}
 	ctrl.selectedElement = {};
-	ctrl.selectedElementActions = {};
+	ctrl.selectedElementActions = null;
 	const configs = {
 		graph: {},
 		paper: {},
@@ -149,7 +149,7 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 	ctrl.unselectAll = () => {
 		ctrl.showFeedback(false, "");
 		ctrl.onSelectElement(null);
-		if(configs.selectedElementActions) {
+		if(configs.selectedElementActions != null) {
 			configs.selectedElementActions.remove();
 			configs.selectedElementActions = null;
 		}
@@ -346,12 +346,15 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 
 	const registerPaperEvents = (paper) => {
 		paper.on('blank:pointerdown', (evt) => {
-			ctrl.unselectAll();
-			if(!configs.keyboardController.spacePressed){
-				configs.elementSelector.start(evt);
-			} else {
-				configs.editorScroller.startPanning(evt);
-			}
+			console.log('blank:pointerdown');
+			// ctrl.unselectAll();
+			// if(!configs.keyboardController.spacePressed){
+			//	configs.elementSelector.start(evt);
+			// } else {
+			// 	configs.editorScroller.startPanning(evt);
+			// }
+
+			//configs.editorActions.setCopyContext(evt);
 		});
 
 		paper.on('link:options', (cellView) => {
@@ -396,11 +399,12 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 		configs.keyboardController.registerHandler(types.ZOOM_IN, () => ctrl.zoomIn());
 		configs.keyboardController.registerHandler(types.ZOOM_OUT, () => ctrl.zoomOut());
 		configs.keyboardController.registerHandler(types.ZOOM_NONE, () => ctrl.zoomNone());
-		configs.keyboardController.registerHandler(types.ESC, () => ctrl.unselectAll());
+		// configs.keyboardController.registerHandler(types.ESC, () => ctrl.unselectAll());
+		// configs.keyboardController.registerHandler(types.COPY, () => configs.editorActions.copyElement(ctrl.selectedElement));
+		// configs.keyboardController.registerHandler(types.PASTE, () => configs.editorActions.pasteElement());
 	}
 
 	const registerGraphEvents = (graph) => {
-
 		graph.on("change", () => {
 			setIsDirty(true);
 		});
@@ -435,14 +439,6 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 			if(ctrl.shapeValidator.isComposedAttribute(model)) {
 				ctrl.makeComposedAttribute(model);
 			}
-
-			// 	if(cellView != null && (cs.isAttribute(cell) || cs.isKey(cell))){
-			// 		var x = cellView.model.attributes.position.x;
-			// 		var y = cellView.model.attributes.position.y;
-			// 		if(x != null && y != null){
-			// 			$scope.conectElements(cellView, x, y);
-			// 		}
-			// 	}
 		});
 
 	}
@@ -481,11 +477,11 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 			paper: configs.paper,
 		});
 
-		configs.editorActions = new joint.ui.EditorActions({ graph: configs.graph });
+		configs.editorActions = new joint.ui.EditorActions({ graph: configs.graph, paper: configs.paper });
 
 		$(".elements-holder").append(enditorManager.render().el);
 
-		configs.elementSelector = new joint.ui.ElementSelector({ paper: configs.paper, graph: configs.graph, model: new Backbone.Collection });
+		// configs.elementSelector = new joint.ui.ElementSelector({ paper: configs.paper, graph: configs.graph, model: new Backbone.Collection });
 
 		enditorManager.loadElements([
 			ctrl.shapeFactory.createEntity({ position: { x: 25, y: 10 } }),

--- a/app/angular/conceptual/conceptual.js
+++ b/app/angular/conceptual/conceptual.js
@@ -7,7 +7,7 @@ import "../editor/editorManager";
 import "../editor/editorScroller";
 import "../editor/editorActions";
 import "../editor/elementActions";
-//import "../editor/elementSelector";
+import "../editor/elementSelector";
 
 import shapes from "../../joint/shapes";
 joint.shapes.erd = shapes;
@@ -46,12 +46,12 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 		user: $rootScope.loggeduser
 	}
 	ctrl.selectedElement = {};
-	ctrl.selectedElementActions = null;
 	const configs = {
 		graph: {},
 		paper: {},
 		editorActions: {},
 		keyboardController: null,
+		selectedElementActions: null
 	};
 
 	const setIsDirty = (isDirty) => {
@@ -346,15 +346,13 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 
 	const registerPaperEvents = (paper) => {
 		paper.on('blank:pointerdown', (evt) => {
-			console.log('blank:pointerdown');
-			// ctrl.unselectAll();
-			// if(!configs.keyboardController.spacePressed){
-			//	configs.elementSelector.start(evt);
-			// } else {
-			// 	configs.editorScroller.startPanning(evt);
-			// }
-
-			//configs.editorActions.setCopyContext(evt);
+			ctrl.unselectAll();
+			if(!configs.keyboardController.spacePressed){
+				configs.elementSelector.start(evt);
+			} else {
+				configs.editorScroller.startPanning(evt);
+			}
+			configs.editorActions.setCopyContext(evt);
 		});
 
 		paper.on('link:options', (cellView) => {
@@ -399,9 +397,10 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 		configs.keyboardController.registerHandler(types.ZOOM_IN, () => ctrl.zoomIn());
 		configs.keyboardController.registerHandler(types.ZOOM_OUT, () => ctrl.zoomOut());
 		configs.keyboardController.registerHandler(types.ZOOM_NONE, () => ctrl.zoomNone());
-		// configs.keyboardController.registerHandler(types.ESC, () => ctrl.unselectAll());
-		// configs.keyboardController.registerHandler(types.COPY, () => configs.editorActions.copyElement(ctrl.selectedElement));
-		// configs.keyboardController.registerHandler(types.PASTE, () => configs.editorActions.pasteElement());
+		configs.keyboardController.registerHandler(types.ESC, () => ctrl.unselectAll());
+		configs.keyboardController.registerHandler(types.COPY, () => configs.editorActions.copyElement(ctrl.selectedElement.element));
+		configs.keyboardController.registerHandler(types.PASTE, () => configs.editorActions.pasteElement());
+		configs.keyboardController.registerHandler(types.DELETE, () => configs.selectedElementActions?.removeElement() );
 	}
 
 	const registerGraphEvents = (graph) => {
@@ -481,7 +480,7 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 
 		$(".elements-holder").append(enditorManager.render().el);
 
-		// configs.elementSelector = new joint.ui.ElementSelector({ paper: configs.paper, graph: configs.graph, model: new Backbone.Collection });
+		configs.elementSelector = new joint.ui.ElementSelector({ paper: configs.paper, graph: configs.graph, model: new Backbone.Collection });
 
 		enditorManager.loadElements([
 			ctrl.shapeFactory.createEntity({ position: { x: 25, y: 10 } }),

--- a/app/angular/editor/editorActions.js
+++ b/app/angular/editor/editorActions.js
@@ -128,12 +128,23 @@ joint.ui.EditorActions = Backbone.Model.extend({
 	copyElement: function (element) {
 		if(element != null) {
 			this.copyContext.element = element.model.clone();
+			const oginalPos = element.model.attributes.position
+			this.setCopyContext({
+				"clientX": oginalPos.x + 25,
+				"clientY": oginalPos.y + 25,
+				"type": "originalposition"
+			})
+			console.log(element);
 		}
     },
 	setCopyContext: function (event) {
 		if(this.copyContext.element != null) {
 			const normalizedEvent = joint.util.normalizeEvent(event);
-			const localPoint = this.paper.clientToLocalPoint({ x: normalizedEvent.clientX, y: normalizedEvent.clientY })
+			console.log(event);
+			let localPoint = { x: normalizedEvent.clientX, y: normalizedEvent.clientY }
+			if(event.type === "mousedown") {
+				localPoint = this.paper.clientToLocalPoint({ x: normalizedEvent.clientX, y: normalizedEvent.clientY })
+			}
 			this.copyContext.event = {
 				"x": localPoint.x,
 				"y": localPoint.y

--- a/app/angular/editor/editorActions.js
+++ b/app/angular/editor/editorActions.js
@@ -11,7 +11,6 @@ joint.ui.EditorActions = Backbone.Model.extend({
         REMOVE: "remove"
     },
     initialize: function (configs) {
-		console.log("initialize EditorActions");
 		this.initCommands = this.initCommands.bind(this);
 		this.storeCommands = this.storeCommands.bind(this);
 		this.setCopyContext = this.setCopyContext.bind(this);
@@ -126,9 +125,9 @@ joint.ui.EditorActions = Backbone.Model.extend({
             this.batchLevel--;
         }
     },
-	copyElement: function (elementView) {
-		if(elementView != null && elementView.element != null) {
-			this.copyContext.element = elementView.element.model.clone();
+	copyElement: function (element) {
+		if(element != null) {
+			this.copyContext.element = element.model.clone();
 		}
     },
 	setCopyContext: function (event) {

--- a/app/angular/editor/editorScroller.js
+++ b/app/angular/editor/editorScroller.js
@@ -17,6 +17,7 @@ joint.ui.EditorScroller = Backbone.View.extend({
 			contentOptions: undefined
 		},
 		initialize(configs) {
+			console.log("start EditorScroller");
 			this.startPanning = this.startPanning.bind(this);
 			this.stopPanning = this.stopPanning.bind(this);
 			this.pan = this.pan.bind(this);
@@ -73,15 +74,19 @@ joint.ui.EditorScroller = Backbone.View.extend({
 			return joint.g.point(clientWidth, clientHeight);
 		},
 		adjustPaper() {
-			const { clientWidth, clientHeight } = this.el;
-			this._center = this.toLocalPoint(clientWidth / 2, clientHeight / 2);
-			const newContentOptions = {
-				gridWidth: this.options.baseWidth,
-				gridHeight: this.options.baseHeight,
-				allowNewOrigin: "negative",
-				...this.options.contentOptions
-			};
-			this.options.paper.fitToContent(this.transformContentOptions(newContentOptions));
+			try {
+				const { clientWidth, clientHeight } = this.el;
+				this._center = this.toLocalPoint(clientWidth / 2, clientHeight / 2);
+				const newContentOptions = {
+					gridWidth: this.options.baseWidth,
+					gridHeight: this.options.baseHeight,
+					allowNewOrigin: "negative",
+					...this.options.contentOptions
+				};
+				this.options.paper.fitToContent(this.transformContentOptions(newContentOptions));
+			} catch (error) {
+				console.log(error);
+			}
 			return this;
 		},
 		adjustScale: function(zoomWidth, zoomHeight) {

--- a/app/angular/editor/editorScroller.js
+++ b/app/angular/editor/editorScroller.js
@@ -17,7 +17,6 @@ joint.ui.EditorScroller = Backbone.View.extend({
 			contentOptions: undefined
 		},
 		initialize(configs) {
-			console.log("start EditorScroller");
 			this.startPanning = this.startPanning.bind(this);
 			this.stopPanning = this.stopPanning.bind(this);
 			this.pan = this.pan.bind(this);
@@ -136,14 +135,8 @@ joint.ui.EditorScroller = Backbone.View.extend({
 				halfWidth *= viewportCTM.a;
 				halfHeight *= viewportCTM.d;
 			}
-			const paddingReference = this.options.padding;
 			const clientWidth = this.el.clientWidth / 2;
 			const clientHeight = this.el.clientHeight / 2;
-			const left = clientWidth - paddingReference - halfWidth + svgMatrixE;
-			const right = clientWidth - paddingReference + halfWidth - paperWidth;
-			const top = clientHeight - paddingReference - halfHeight + e;
-			const bottom = clientHeight - paddingReference + halfHeight - paperHeight;
-			this.addPadding(Math.max(left, 0), Math.max(right, 0), Math.max(top, 0), Math.max(bottom, 0));
 			this.el.scrollLeft = halfWidth - clientWidth + viewportCTM.e + this.padding.paddingLeft;
 			this.el.scrollTop = halfHeight - clientHeight + viewportCTM.f + this.padding.paddingTop;
 			return this;

--- a/app/angular/editor/elementActions.js
+++ b/app/angular/editor/elementActions.js
@@ -40,7 +40,6 @@ joint.ui.ElementActions = Backbone.View.extend({
         linkAttributes: {}
     },
 	initialize(configs) {
-		console.log("start ElementActions");
 		this.options = { ...this.options, ...configs } || {};
 		this.options = {
 			...this.options,

--- a/app/angular/editor/elementActions.js
+++ b/app/angular/editor/elementActions.js
@@ -40,6 +40,7 @@ joint.ui.ElementActions = Backbone.View.extend({
         linkAttributes: {}
     },
 	initialize(configs) {
+		console.log("start ElementActions");
 		this.options = { ...this.options, ...configs } || {};
 		this.options = {
 			...this.options,
@@ -52,6 +53,7 @@ joint.ui.ElementActions = Backbone.View.extend({
 		this.render = this.render.bind(this);
 		this.updateElement = this.updateElement.bind(this);
 		this.remove = this.remove.bind(this);
+
 
 		joint.ui.ElementActions.clear(this.options.paper);
 		this.listenTo(this.options.graph, "reset", this.remove);

--- a/app/angular/editor/elementSelector.js
+++ b/app/angular/editor/elementSelector.js
@@ -15,7 +15,6 @@ joint.ui.ElementSelector = Backbone.View.extend({
         "touchstart .selection-box": "startVisualSelection",
     },
 	initialize(a) {
-		console.log("start ElementSelector");
 		this.options = { ...this.options, ...a } || {};
 
 		this.options = {

--- a/app/angular/editor/elementSelector.js
+++ b/app/angular/editor/elementSelector.js
@@ -15,6 +15,7 @@ joint.ui.ElementSelector = Backbone.View.extend({
         "touchstart .selection-box": "startVisualSelection",
     },
 	initialize(a) {
+		console.log("start ElementSelector");
 		this.options = { ...this.options, ...a } || {};
 
 		this.options = {

--- a/app/angular/service/logicService.js
+++ b/app/angular/service/logicService.js
@@ -51,7 +51,7 @@ const logicService = ($rootScope, ModelAPI, LogicFactory, LogicConversorService)
 			linkPinning: false
 		});
 
-		ls.editorActions = new joint.ui.EditorActions({ graph: ls.graph });
+		ls.editorActions = new joint.ui.EditorActions({graph: ls.graph, paper: ls.paper});
 
 		ls.keyboardController = new KeyboardController(ls.paper.$document);
 
@@ -180,6 +180,8 @@ const logicService = ($rootScope, ModelAPI, LogicFactory, LogicConversorService)
 			} else {
 				ls.editorScroller.startPanning(evt);
 			}
+
+			ls.editorActions.setCopyContext(evt);
 		});
 
 		ls.getConnectionType = link => {
@@ -477,6 +479,9 @@ const logicService = ($rootScope, ModelAPI, LogicFactory, LogicConversorService)
 			ls.updateModel();
 			$rootScope.$broadcast('model:saved')
 		});
+		ls.keyboardController.registerHandler(types.COPY, () => ls.editorActions.copyElement(ls.selectedElement));
+		ls.keyboardController.registerHandler(types.PASTE, () => ls.editorActions.pasteElement());
+		ls.keyboardController.registerHandler(types.DELETE, () => ls.selectedActions?.removeElement() );
 	}
 
 	ls.getTablesMap = function () {


### PR DESCRIPTION
# Summary

add a new set of keyboard shortcuts.

`cmd` (Mac) == `ctrl` (Windows)

- [x] Keyboard shortcut - `cmd` + `c` = Copy selected element (Single element only.  For now)
- [x] Keyboard shortcut - `cmd` + `v` = Paste copied element
- [x] Keyboard shortcut - `backspace`  = Delete selected element (If element selected)

# Related issues

- Close #428
- Close #332