### PR TITLE
BlockAssociative without naming and Delete name when renaming

### DIFF
--- a/app/angular/conceptual/sidebarControl.js
+++ b/app/angular/conceptual/sidebarControl.js
@@ -68,7 +68,7 @@ const controller = function($rootScope, $timeout) {
 	}
 
 	$ctrl.updateName = (newName) => {
-		if (newName != "") {
+		if (newName != null) {
 			$ctrl.onUpdate({
 				"event": {
 					"type": "name",

--- a/app/joint/shapes.js
+++ b/app/joint/shapes.js
@@ -147,15 +147,21 @@ erd.Associative = joint.dia.Element.extend({
 erd.BlockAssociative = joint.dia.Element.extend({
   markup: '<g class="rotatable"><g class="scalable"><polygon class="outer"/></g><text/></g>',
   defaults: _.defaultsDeep({
-      type: 'erd.BlockAssociative',
-      supertype: 'Entity',
-      size: { width: 100, height: 50 },
-      attrs: {
-          '.outer': {
-              fill: 'white', stroke: 'black',
-              points: '100,0 100,60 0,60 0,0'
-          }
-      }
+		type: 'erd.BlockAssociative',
+		supertype: 'Entity',
+		size: { width: 100, height: 50 },
+		attrs: {
+			'.outer': {
+					fill: 'white', stroke: 'black',
+					points: '100,0 100,60 0,60 0,0'
+			},
+			text: {
+				text: '',
+				'font-family': 'Arial', 'font-size': 12,
+				ref: '.outer', 'ref-x': .1, 'ref-y': .05,
+				'x-alignment': 'start', 'y-alignment': 'start'
+			}
+    }
   }, joint.dia.Element.prototype.defaults)
 });
 


### PR DESCRIPTION
Está PR é para corrigir o bug da issue [489](https://github.com/brmodeloweb/brmodelo-app/issues/489), onde não era possível nomear a entidade associativa.

Estou enviando um giff mostrando a correção funcionando.

![2024-01-18-22-53-05](https://github.com/brmodeloweb/brmodelo-app/assets/99288913/7c10c8c2-5c1b-474b-aec9-9e2afe45b87e)