### PR TITLE
Docker image improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules/
+.git/
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM node:16-alpine
-RUN mkdir -p /usr/src/app
-ENV APP_PATH /usr/src/app
-COPY package.json $APP_PATH
-WORKDIR $APP_PATH
-RUN yarn install
-COPY . $APP_PATH
+
+WORKDIR /usr/src/app
+
+COPY yarn.lock package.json .
+
+RUN --mount=type=cache,target=/root/.yarn --mount=type=cache,target=/root/.cache YARN_CACHE_FOLDER=/root/.yarn yarn install
+
+COPY . .
+
 # expose port 3000 for server and 9000 for webpack-dev-server
 EXPOSE 3000 9000
+
 # run start:frontend and start:dev in parallel
 CMD ["yarn", "start:frontend", "start:dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 services:
   mongo:
     container_name: mongo


### PR DESCRIPTION
This PR removes unnecessary commands in the Dockerfile such as mkdir (WORKDIR creates it if it's not there.
Adding a cache to the yarn install command will speed up builds when updating any dependency.

The final image was being build with the `data` folder created by docker-compose mongo container and the `.git` folder, increasing its size.
The image size went from 1.3~GB to around 400MB.
