### PR TITLE
Remove first level bugReport

### DIFF
--- a/app/angular/conceptual/conceptual.html
+++ b/app/angular/conceptual/conceptual.html
@@ -58,6 +58,5 @@
 			</header><!-- End .workspace-header -->
 		</section><!-- End .model-area -->
 		<sidebar-control-conceptual selected="$ctrl.selectedElement" on-update="$ctrl.onUpdate(event)"></sidebar-control-conceptual>
-		<bug-report-button></bug-report-button>
 	</div><!-- End .mainContent -->
 </section><!-- End .view -->

--- a/app/angular/conceptual/conceptual.js
+++ b/app/angular/conceptual/conceptual.js
@@ -18,7 +18,6 @@ import template from "./conceptual.html";
 import modelDuplicatorComponent from "../components/duplicateModelModal";
 import shareModelModal from "../components/shareModelModal";
 import statusBar from "../components/statusBar";
-import bugReportButton from "../components/bugReportButton";
 
 import Factory from "./factory";
 import Validator from "./validator";
@@ -593,7 +592,13 @@ const controller = function (ModelAPI, $stateParams, $rootScope, $timeout, $uibM
 };
 
 export default angular
-	.module("app.workspace.conceptual", [modelDuplicatorComponent, preventExitServiceModule, bugReportButton, statusBar, shareModelModal, iconConceptual])
+	.module("app.workspace.conceptual", [
+		modelDuplicatorComponent,
+		preventExitServiceModule,
+		statusBar,
+		shareModelModal,
+		iconConceptual
+	])
 	.component("editorConceptual", {
 		template,
 		controller,

--- a/app/angular/logic/logic.html
+++ b/app/angular/logic/logic.html
@@ -64,6 +64,5 @@
 			</header><!-- End .workspace-header -->
 		</section><!-- End .model-area -->
 		<sidebar-control-logical selected="$ctrl.selectedElement" show-feedback="$ctrl.showFeedback"></sidebar-control-logical>
-		<bug-report-button></bug-report-button>
 	</section><!-- End .mainContent -->
 </section><!-- End .view -->

--- a/app/angular/logic/logic.js
+++ b/app/angular/logic/logic.js
@@ -6,7 +6,6 @@ import duplicateModelModal from "../components/duplicateModelModal";
 import shareModelModal from "../components/shareModelModal";
 import queryExpressionModal from "../components/queryExpressionModal";
 import sqlComparasionDropdown from "../components/sqlComparasionDropdown";
-import bugReportButton from "../components/bugReportButton";
 import statusBar from "../components/statusBar";
 import preventExitServiceModule from "../service/preventExitService";
 import view from "../view/view";
@@ -267,7 +266,21 @@ const controller = function (
 };
 
 export default angular
-	.module("app.workspace.logic", [sqlGeneratorService, sqlGeneratorModal, duplicateModelModal, preventExitServiceModule, bugReportButton, statusBar, view, columnForm, sidebarControlLogical, checkConstraint, queryExpressionModal, sqlComparasionDropdown, shareModelModal, iconLogic])
+	.module("app.workspace.logic", [
+		sqlGeneratorService,
+		sqlGeneratorModal,
+		duplicateModelModal,
+		preventExitServiceModule,
+		statusBar,
+		view,
+		columnForm,
+		sidebarControlLogical,
+		checkConstraint,
+		queryExpressionModal,
+		sqlComparasionDropdown,
+		shareModelModal,
+		iconLogic
+	])
 	.component("editorLogic", {
 		template,
 		controller,

--- a/app/angular/workspace/workspace.html
+++ b/app/angular/workspace/workspace.html
@@ -83,8 +83,5 @@
 		<div class="container">
 			<github-sponsor-banner></github-sponsor-banner>
 		</div> 
-
-		<bug-report-button></bug-report-button>
-
 	</section><!-- End .mainContent -->
 </section><!-- End .view -->

--- a/app/angular/workspace/workspace.js
+++ b/app/angular/workspace/workspace.js
@@ -6,7 +6,6 @@ import modelCreateComponent from "../components/createModelModal";
 import modelDuplicatorComponent from "../components/duplicateModelModal";
 import modelDeleterComponent from "../components/deleteModelModal";
 import modelRenameComponent from "../components/renameModelModal";
-import bugReportButton from "../components/bugReportButton";
 import modelImportComponent from "../components/importModelModal";
 import githubSponsorBanner from "../components/githubSponsorBanner";
 import shareModelModal from "../components/shareModelModal";
@@ -220,7 +219,6 @@ export default angular
 		modelDuplicatorComponent,
 		modelDeleterComponent,
 		modelRenameComponent,
-		bugReportButton,
 		modelImportComponent,
 		githubSponsorBanner,
 		shareModelModal,

--- a/app/sass/buttons.scss
+++ b/app/sass/buttons.scss
@@ -79,29 +79,3 @@
 	background-color: transparent;
 	color: var(--brand-default);
 }
-
-////////////////////////////////////////////////////////////////////////////////
-// .br-help
-////////////////////////////////////////////////////////////////////////////////
-
-.br-help {
-	position: fixed;
-	z-index: 10;
-	bottom: 6px;
-	left: 6px;
-	font-size: 2em;
-	width: 42px;
-	height: 42px;
-	text-align: center;
-	border-radius: 100%;
-	text-decoration: none;
-	transition: 0.1s ease-in-out transform
-}
-
-.br-help:visited {
-	color: var(--brand-default);
-}
-
-.br-help:hover {
-	transform: rotate(35deg)
-}


### PR DESCRIPTION
# Summary 

The _Bug icon_ present at  _Models list_ and both Logic and Conceptual _workspaces_ takes a prime space in the screen which we plan to use in other ways. Due to that we're removing bugReport and relying at the option inside the UserMenu present in _Models list_ view.

# Screenshots

| Before | After |
| ------- | ----- |
![App brmodeloweb](https://github.com/brmodeloweb/brmodelo-app/assets/301545/3918a050-e93f-4e4f-85d5-1341c0802f3d) |  ![DevTools localhost](https://github.com/brmodeloweb/brmodelo-app/assets/301545/5c2a2e75-db28-42ab-9624-f1a8525782d2) |

Same change visible in the screenshots apply to both logic and conceptual workspaces
