### PR TITLE
Fix buggy behavior on .elements-holder child elements

### DIFF
--- a/app/angular/editor/editorManager.js
+++ b/app/angular/editor/editorManager.js
@@ -22,8 +22,8 @@ joint.templates.draggable["draggable-paper.html"] = Handlebars.template(() => {
 joint.ui.EditorManager = Backbone.View.extend({
     className: "elements-list",
     options: {
-        width: 126,
-        height: 500
+        width: `100%`,
+        height: `calc(100vh - 75px)` // Magic number:  ~ .navbar height
     },
 	initialize(configs) {
 		this.options = { ...this.options, ...configs } || {};

--- a/app/sass/structure.scss
+++ b/app/sass/structure.scss
@@ -89,10 +89,6 @@ a:hover,
 	bottom: 0;
 	left: 0;
 	max-width: 150px;
-	display: flex;
-	flex-direction: column;
-	flex-direction: column-reverse;
-	justify-content: space-between;
 	padding: 12px;
 	border-right: 1px solid var(--border-default);
 	background-color: var(--gray-95);
@@ -107,6 +103,24 @@ a:hover,
 
 .elements-holder .elements-list .elements {
 	background-color: transparent;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ..elements-holder support-banners-list
+////////////////////////////////////////////////////////////////////////////////
+
+// Hide by default
+.elements-holder support-banners-list {display: none;}
+
+// Only show if screen height is larger enough to show all items from
+// .elements-list in conceptual workspace (The one with more elements)
+@media screen and (min-height: 620px) {
+	.elements-holder support-banners-list {
+		display: block;
+		position: fixed;
+		bottom: 0;
+		z-index: 1;
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Summary

After we introduce `<support-banner-list>` at models workplace, some buggy behaviors start to happen when window height was short:

- We move elements under the `.navbar`, making it impossible to drag some of it to the canvas
- In some cases the banner list was on top of element making it impossible to drag them to the canvas

This pull request fix those problems by:

- Only show `<support-banner-list>` if the window is at least 620px tall
- Move away from the flex display since it simplify a bit the amount of overwrites are needed to make everything work smoothly

# Video

https://github.com/brmodeloweb/brmodelo-app/assets/301545/d9aa365b-86b3-4dec-8a66-b89a3600a289

