### PR TITLE
Docs: add v2 migration notice at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+> [!IMPORTANT]
+> ## 🚧 V2 Migration in Progress
+>
+> The application is currently migrating to **v2**. This includes:
+> - Full migration from AngularJS to **React**
+> - Rewrite of all editors
+> - Bug fixes and usability improvements
+> - New **NoSQL** modeling support
+>
+> **This repository is temporarily out of sync with the live application at [app.brmodeloweb.com](https://app.brmodeloweb.com/).**
+>
+> Until the migration is complete (over the next few weeks), we will **not** be updating this public repository nor accepting external contributions. Once the migration is finalized, the repo will be updated with the new version.
+>
+> Thank you for your patience!
+
 # [app.brmodeloweb.com](https://app.brmodeloweb.com)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-19-orange.svg?style=flat-square)](#contributors-)


### PR DESCRIPTION
## Summary
Adds a prominent \`> [!IMPORTANT]\` callout at the top of the README informing visitors that:

- The application is migrating to **v2** (React rewrite, editor rewrites, bug fixes, usability improvements, NoSQL modeling)
- This repository is temporarily **out of sync** with the live app at [app.brmodeloweb.com](https://app.brmodeloweb.com/)
- **No public repo updates or external contributions** will be accepted until the migration is finalized over the next few weeks
- The repo will be updated once the migration is complete

## Rationale
The v2 work is happening in a private repo during the migration. Without a notice, external contributors may submit PRs against an outdated codebase and users may report bugs already fixed in the new version.

## Preview
The GitHub \`[!IMPORTANT]\` callout renders as a blue banner with the warning triangle icon, placed before the main title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a notice regarding an upcoming migration to v2. The public repository will be temporarily out of sync and will not accept external contributions during the migration period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->