### PR TITLE
Docs: align contributions note with v2 migration pause, drop broken hero shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
 
 ## Web application for database modeling and teaching
 
-![Hero shot](https://www.brmodeloweb.com/img/hero-shot-pt-br.png)
 > Released under the [Apache License 2.0](https://choosealicense.com/licenses/apache-2.0/)
 
 ## Dependencies
@@ -124,4 +123,4 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome — please note that external contributions are **temporarily paused** while the v2 migration is in progress (see the notice at the top of this README).


### PR DESCRIPTION
## Summary
Two small README fixes:

1. **Align footer with v2 migration notice.** CodeRabbit flagged on #654 that the footer sentence \"Contributions of any kind welcome!\" contradicts the migration notice at the top (which says external contributions are temporarily paused). Softens the footer to state that contributions are welcome in general but temporarily paused during the v2 migration, pointing readers back to the notice at the top.

2. **Remove broken hero-shot image.** The asset at \`brmodeloweb.com/img/hero-shot-pt-br.png\` is no longer reachable and renders as a broken image in the README.

## Preview
- Line 23 (hero shot): removed
- Line ~127 (contributions footer): reworded to acknowledge the temporary pause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributors acknowledgments section with an explicit status clarification noting that external contributions are temporarily paused while the v2 migration is underway.
  * Improved documentation structure and consistency by streamlining the project overview section and strengthening cross-references to the primary migration notice at the top of the file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->